### PR TITLE
Properly clean up photoCaptureObject on destroy

### DIFF
--- a/Assets/LocatableCamera/Scripts/LocatableCamera.cs
+++ b/Assets/LocatableCamera/Scripts/LocatableCamera.cs
@@ -41,6 +41,21 @@ namespace Microsoft.MixedReality.OpenXR.Samples
             }
         }
 
+        private void OnDestroy()
+        {
+            isReadyToCapturePhoto = false;
+
+            if (photoCaptureObject != null)
+            {
+                photoCaptureObject.StopPhotoModeAsync(OnPhotoCaptureStopped);
+
+                if (text != null)
+                {
+                    text.text = "Stopping camera...";
+                }
+            }
+        }
+
         private void OnPhotoCaptureCreated(PhotoCapture captureObject)
         {
             if (text != null)
@@ -165,6 +180,17 @@ namespace Microsoft.MixedReality.OpenXR.Samples
             }
 
             isCapturingPhoto = false;
+        }
+
+        private void OnPhotoCaptureStopped(PhotoCapture.PhotoCaptureResult result)
+        {
+            if (text != null)
+            {
+                text.text = result.success ? "Photo mode stopped." : "Unable to stop photo mode.";
+            }
+
+            photoCaptureObject.Dispose();
+            photoCaptureObject = null;
         }
     }
 }


### PR DESCRIPTION
Fixes 

```
Photo Mode has already been started.
UnityEngine.Windows.WebCam.PhotoCapture:StartPhotoModeAsync (UnityEngine.Windows.WebCam.CameraParameters,UnityEngine.Windows.WebCam.PhotoCapture/OnPhotoModeStartedCallback)
Microsoft.MixedReality.OpenXR.Samples.LocatableCamera:OnPhotoCaptureCreated (UnityEngine.Windows.WebCam.PhotoCapture) (at Assets/Examples/MainSample/Scripts/LocatableCamera.cs:61)
UnityEngine.Windows.WebCam.PhotoCapture:InvokeOnCreatedResourceDelegate (UnityEngine.Windows.WebCam.PhotoCapture/OnCaptureResourceCreatedCallback,intptr)
```

when moving back and forth between the locatable camera scene.