### PR TITLE
ARMeshUpdateFollowsUser - subsystem null check

### DIFF
--- a/BasicSample/Assets/ARMesh/Scripts/ARMeshUpdateFollowsUser.cs
+++ b/BasicSample/Assets/ARMesh/Scripts/ARMeshUpdateFollowsUser.cs
@@ -6,31 +6,31 @@ using UnityEngine.XR.ARFoundation;
 
 namespace Microsoft.MixedReality.OpenXR.BasicSample
 {
-    /// <summary>
-    /// Updates the mesh bounding volume every frame to follow the user's head.
-    /// </summary>
-    public class ARMeshUpdateFollowsUser : MonoBehaviour
-    {
-        [SerializeField]
-        private ARMeshManager meshManager = null;
+	/// <summary>
+	/// Updates the mesh bounding volume every frame to follow the user's head.
+	/// </summary>
+	public class ARMeshUpdateFollowsUser : MonoBehaviour
+	{
+		[SerializeField]
+		private ARMeshManager meshManager = null;
 
-        [SerializeField]
-        private Vector3 boundingExtents = Vector3.one * 3;
+		[SerializeField]
+		private Vector3 boundingExtents = Vector3.one * 3;
 
-        private void Awake()
-        {
-            if (meshManager == null && !TryGetComponent(out meshManager))
-            {
-                Debug.LogError($"No {nameof(ARMeshManager)} was provided to {nameof(ARMeshUpdateFollowsUser)} on {name}.");
-            }
-        }
+		private void Awake()
+		{
+			if (meshManager == null && !TryGetComponent(out meshManager))
+			{
+				Debug.LogError($"No {nameof(ARMeshManager)} was provided to {nameof(ARMeshUpdateFollowsUser)} on {name}.");
+			}
+		}
 
-        private void Update()
-        {
-            if (meshManager != null)
-            {
-                meshManager.subsystem.SetBoundingVolume(Camera.main.transform.position, boundingExtents);
-            }
-        }
-    }
+		private void Update()
+		{
+			if (meshManager != null)
+			{
+				meshManager.subsystem?.SetBoundingVolume(Camera.main.transform.position, boundingExtents);
+			}
+		}
+	}
 }

--- a/BasicSample/Assets/ARMesh/Scripts/ARMeshUpdateFollowsUser.cs
+++ b/BasicSample/Assets/ARMesh/Scripts/ARMeshUpdateFollowsUser.cs
@@ -6,31 +6,31 @@ using UnityEngine.XR.ARFoundation;
 
 namespace Microsoft.MixedReality.OpenXR.BasicSample
 {
-	/// <summary>
-	/// Updates the mesh bounding volume every frame to follow the user's head.
-	/// </summary>
-	public class ARMeshUpdateFollowsUser : MonoBehaviour
-	{
-		[SerializeField]
-		private ARMeshManager meshManager = null;
+    /// <summary>
+    /// Updates the mesh bounding volume every frame to follow the user's head.
+    /// </summary>
+    public class ARMeshUpdateFollowsUser : MonoBehaviour
+    {
+        [SerializeField]
+        private ARMeshManager meshManager = null;
 
-		[SerializeField]
-		private Vector3 boundingExtents = Vector3.one * 3;
+        [SerializeField]
+        private Vector3 boundingExtents = Vector3.one * 3;
 
-		private void Awake()
-		{
-			if (meshManager == null && !TryGetComponent(out meshManager))
-			{
-				Debug.LogError($"No {nameof(ARMeshManager)} was provided to {nameof(ARMeshUpdateFollowsUser)} on {name}.");
-			}
-		}
+        private void Awake()
+        {
+            if (meshManager == null && !TryGetComponent(out meshManager))
+            {
+                Debug.LogError($"No {nameof(ARMeshManager)} was provided to {nameof(ARMeshUpdateFollowsUser)} on {name}.");
+            }
+        }
 
-		private void Update()
-		{
-			if (meshManager != null)
-			{
-				meshManager.subsystem?.SetBoundingVolume(Camera.main.transform.position, boundingExtents);
-			}
-		}
-	}
+        private void Update()
+        {
+            if (meshManager != null)
+            {
+                meshManager.subsystem?.SetBoundingVolume(Camera.main.transform.position, boundingExtents);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Sometimes (ex. in play mode remoting) the ARMeshManager exists, but doesn't have a valid subsystem. In this case, we avoid a NullReferenceException with this check.