### PR TITLE
Add new flag for setting up app remoting for build

### DIFF
--- a/BasicSample/Assets/Build/BuildApp.cs
+++ b/BasicSample/Assets/Build/BuildApp.cs
@@ -1,11 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.MixedReality.OpenXR.Remoting;
 using System;
 using System.Linq;
 using UnityEditor;
 using UnityEditor.Build.Reporting;
+using UnityEditor.XR.Management;
+using UnityEditor.XR.OpenXR.Features;
 using UnityEngine;
+using UnityEngine.XR.Management;
+using UnityEngine.XR.OpenXR;
+using UnityEngine.XR.OpenXR.Features;
 
 namespace Microsoft.MixedReality.OpenXR.BasicSample.Build
 {
@@ -59,6 +65,9 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample.Build
                     case "-buildOutput":
                         buildPath = arguments[++i];
                         break;
+                    case "-appRemoting":
+                        SetUpAppRemoting(BuildPipeline.GetBuildTargetGroup(EditorUserBuildSettings.activeBuildTarget));
+                        break;
                 }
             }
         }
@@ -67,6 +76,34 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample.Build
         {
             return (from scene in sceneList.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                     select scene.Trim()).ToArray();
+        }
+
+        private static void SetUpAppRemoting(BuildTargetGroup targetGroup)
+        {
+            Debug.Log($"Setting up app remoting for {targetGroup}");
+
+            const string AppRemotingPlugin = "Microsoft.MixedReality.OpenXR.Remoting.AppRemotingPlugin";
+            Type appRemotingFeature = typeof(AppRemoting).Assembly.GetType(AppRemotingPlugin);
+            if (appRemotingFeature == null)
+            {
+                Debug.LogError($"Could not find {AppRemotingPlugin}. Has this class been removed or renamed?");
+                return;
+            }
+
+            FeatureHelpers.RefreshFeatures(targetGroup);
+            OpenXRFeature feature = OpenXRSettings.ActiveBuildTargetInstance.GetFeature(appRemotingFeature);
+            if (feature == null)
+            {
+                Debug.LogError($"Could not load {AppRemotingPlugin} as an OpenXR feature. Has this class been removed or renamed?");
+                return;
+            }
+            feature.enabled = true;
+
+            XRGeneralSettings settings = XRGeneralSettingsPerBuildTarget.XRGeneralSettingsForBuildTarget(targetGroup);
+            if (settings != null)
+            {
+                settings.InitManagerOnStart = false;
+            }
         }
     }
 }

--- a/BasicSample/Assets/Build/Microsoft.MixedReality.OpenXR.BasicSample.Build.asmdef
+++ b/BasicSample/Assets/Build/Microsoft.MixedReality.OpenXR.BasicSample.Build.asmdef
@@ -1,7 +1,13 @@
 {
     "name": "Microsoft.MixedReality.OpenXR.BasicSample.Build",
     "rootNamespace": "Microsoft.MixedReality.OpenXR.BasicSample.Build",
-    "references": [],
+    "references": [
+        "GUID:3b76ab8242cc35d479edf0a949d56d59",
+        "GUID:e40ba710768534012815d3193fa296cb",
+        "GUID:f9fe0089ec81f4079af78eb2287a6163",
+        "GUID:4847341ff46394e83bb78fbd0652937e",
+        "GUID:96aa6ba065960476598f8f643e7252b6"
+    ],
     "includePlatforms": [
         "Editor"
     ],


### PR DESCRIPTION
Adds a new flag to our command line build script to support enabling and configuring app remoting before building. This will help us produce a larger array of test apps from our CI.