### PR TITLE
Updated MRTK packages to latest 2.7.3 version

### DIFF
--- a/BasicSample/Packages/manifest.json
+++ b/BasicSample/Packages/manifest.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "com.microsoft.mixedreality.openxr": "file:../../MixedRealityPackages/com.microsoft.mixedreality.openxr-1.2.1.tgz",
-    "com.microsoft.mixedreality.toolkit.foundation": "file:../../MixedRealityPackages/com.microsoft.mixedreality.toolkit.foundation-2.7.2.tgz",
-    "com.microsoft.mixedreality.toolkit.standardassets": "file:../../MixedRealityPackages/com.microsoft.mixedreality.toolkit.standardassets-2.7.2.tgz",
+    "com.microsoft.mixedreality.toolkit.foundation": "file:../../MixedRealityPackages/com.microsoft.mixedreality.toolkit.foundation-2.7.3.tgz",
+    "com.microsoft.mixedreality.toolkit.standardassets": "file:../../MixedRealityPackages/com.microsoft.mixedreality.toolkit.standardassets-2.7.3.tgz",
     "com.unity.ide.rider": "2.0.7",
     "com.unity.ide.visualstudio": "2.0.12",
     "com.unity.ide.vscode": "1.2.4",

--- a/BasicSample/Packages/packages-lock.json
+++ b/BasicSample/Packages/packages-lock.json
@@ -11,15 +11,15 @@
       }
     },
     "com.microsoft.mixedreality.toolkit.foundation": {
-      "version": "file:../../MixedRealityPackages/com.microsoft.mixedreality.toolkit.foundation-2.7.2.tgz",
+      "version": "file:../../MixedRealityPackages/com.microsoft.mixedreality.toolkit.foundation-2.7.3.tgz",
       "depth": 0,
       "source": "local-tarball",
       "dependencies": {
-        "com.microsoft.mixedreality.toolkit.standardassets": "2.7.2"
+        "com.microsoft.mixedreality.toolkit.standardassets": "2.7.3"
       }
     },
     "com.microsoft.mixedreality.toolkit.standardassets": {
-      "version": "file:../../MixedRealityPackages/com.microsoft.mixedreality.toolkit.standardassets-2.7.2.tgz",
+      "version": "file:../../MixedRealityPackages/com.microsoft.mixedreality.toolkit.standardassets-2.7.3.tgz",
       "depth": 0,
       "source": "local-tarball",
       "dependencies": {

--- a/MixedRealityPackages/com.microsoft.mixedreality.toolkit.foundation-2.7.2.tgz
+++ b/MixedRealityPackages/com.microsoft.mixedreality.toolkit.foundation-2.7.2.tgz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6d104648e260541d93c7613ed74e171b65c6cb9fa7132f49d8804c69ab90b480
-size 8663857

--- a/MixedRealityPackages/com.microsoft.mixedreality.toolkit.foundation-2.7.3.tgz
+++ b/MixedRealityPackages/com.microsoft.mixedreality.toolkit.foundation-2.7.3.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:017679fd7318c6e22317b40e9ef9a530b36384a580d037bce8e913b310051c86
+size 8670682

--- a/MixedRealityPackages/com.microsoft.mixedreality.toolkit.standardassets-2.7.2.tgz
+++ b/MixedRealityPackages/com.microsoft.mixedreality.toolkit.standardassets-2.7.2.tgz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d86f6c392fd3690349f85a7ab2e71a2582e765abe4defdc86cec2cbad334ae96
-size 4696135

--- a/MixedRealityPackages/com.microsoft.mixedreality.toolkit.standardassets-2.7.3.tgz
+++ b/MixedRealityPackages/com.microsoft.mixedreality.toolkit.standardassets-2.7.3.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b15259a3faec69b3181297111713b3b19e31bff3d59be75fda43722ea34ae5b
+size 5303497


### PR DESCRIPTION
This PR updates the MRTK packages from 2.7.2 to 2.7.3. MRTK 2.7.3 fixes the performance issues experienced on HoloLens 2 with the Hand Joints and Hand Mesh in the Hand Tracking examples.