### PR TITLE
Untracked anchor improvements

### DIFF
--- a/BasicSample/Assets/ARAnchor/Materials/PersistentAnchorMaterial.mat
+++ b/BasicSample/Assets/ARAnchor/Materials/PersistentAnchorMaterial.mat
@@ -8,18 +8,24 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: PersistentAnchorMaterial
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: 
+  m_Shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
+  m_ShaderKeywords: _DIRECTIONAL_LIGHT _DISABLE_ALBEDO_MAP _HOVER_LIGHT _REFLECTIONS
+    _SPECULAR_HIGHLIGHTS
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
+  m_CustomRenderQueue: 2000
+  stringTagMap:
+    RenderType: Opaque
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
     - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ChannelMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -39,11 +45,19 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - _IridescentSpectrumMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _MainTex:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -56,23 +70,107 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats:
+    - _AlbedoAlphaMode: 0
+    - _AlbedoAssignedAtRuntime: 0
+    - _BlendOp: 0
+    - _BlendedClippingWidth: 1
+    - _BorderLight: 0
+    - _BorderLightOpaque: 0
+    - _BorderLightOpaqueAlpha: 1
+    - _BorderLightReplacesAlbedo: 0
+    - _BorderLightUsesHoverColor: 0
+    - _BorderMinValue: 0.1
+    - _BorderWidth: 0.1
     - _BumpScale: 1
+    - _ClippingBorder: 0
+    - _ClippingBorderWidth: 0.025
+    - _ColorWriteMask: 15
+    - _CullMode: 2
+    - _CustomMode: 0
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
+    - _DirectionalLight: 1
     - _DstBlend: 0
+    - _EdgeSmoothingValue: 0.002
+    - _EnableChannelMap: 0
+    - _EnableEmission: 0
+    - _EnableHoverColorOverride: 0
+    - _EnableLocalSpaceTriplanarMapping: 0
+    - _EnableNormalMap: 0
+    - _EnableProximityLightColorOverride: 0
+    - _EnableSSAA: 0
+    - _EnableTriplanarMapping: 0
+    - _EnvironmentColorIntensity: 0.5
+    - _EnvironmentColorThreshold: 1.5
+    - _EnvironmentColoring: 0
+    - _FadeBeginDistance: 0.85
+    - _FadeCompleteDistance: 0.5
+    - _FadeMinValue: 0
+    - _FluentLightIntensity: 1
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 1
+    - _HoverLight: 1
+    - _IgnoreZScale: 0
+    - _IndependentCorners: 0
+    - _InnerGlow: 0
+    - _InnerGlowPower: 4
+    - _Iridescence: 0
+    - _IridescenceAngle: -0.78
+    - _IridescenceIntensity: 0.5
+    - _IridescenceThreshold: 0.05
     - _Metallic: 0
+    - _MipmapBias: -2
     - _Mode: 0
+    - _NearLightFade: 0
+    - _NearPlaneFade: 0
+    - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
+    - _ProximityLight: 0
+    - _ProximityLightSubtractive: 0
+    - _ProximityLightTwoSided: 0
+    - _Reflections: 1
+    - _Refraction: 0
+    - _RefractiveIndex: 0
+    - _RenderQueueOverride: -1
+    - _RimLight: 0
+    - _RimPower: 0.25
+    - _RoundCornerMargin: 0.01
+    - _RoundCornerRadius: 0.25
+    - _RoundCorners: 0
+    - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
+    - _SphericalHarmonics: 0
     - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComparison: 0
+    - _StencilOperation: 0
+    - _StencilReference: 0
+    - _TriplanarMappingBlendSharpness: 4
     - _UVSec: 0
+    - _VertexColors: 0
+    - _VertexExtrusion: 0
+    - _VertexExtrusionSmoothNormals: 0
+    - _VertexExtrusionValue: 0
+    - _ZOffsetFactor: 0
+    - _ZOffsetUnits: 0
+    - _ZTest: 4
     - _ZWrite: 1
     m_Colors:
+    - _ClippingBorderColor: {r: 1, g: 0.19999996, b: 0, a: 1}
     - _Color: {r: 0, g: 1, b: 0.51874995, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissiveColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EnvironmentColorX: {r: 1, g: 0, b: 0, a: 1}
+    - _EnvironmentColorY: {r: 0, g: 1, b: 0, a: 1}
+    - _EnvironmentColorZ: {r: 0, g: 0, b: 1, a: 1}
+    - _HoverColorOverride: {r: 1, g: 1, b: 1, a: 1}
+    - _InnerGlowColor: {r: 1, g: 1, b: 1, a: 0.75}
+    - _ProximityLightCenterColorOverride: {r: 1, g: 0, b: 0, a: 0}
+    - _ProximityLightMiddleColorOverride: {r: 0, g: 1, b: 0, a: 0.5}
+    - _ProximityLightOuterColorOverride: {r: 0, g: 0, b: 1, a: 1}
+    - _RimColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _RoundCornersRadius: {r: 0.5, g: 0.5, b: 0.5, a: 0.5}
   m_BuildTextureStacks: []

--- a/BasicSample/Assets/ARAnchor/Materials/TransientAnchorMaterial.mat
+++ b/BasicSample/Assets/ARAnchor/Materials/TransientAnchorMaterial.mat
@@ -8,18 +8,24 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: TransientAnchorMaterial
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: 
+  m_Shader: {fileID: 4800000, guid: 5bdea20278144b11916d77503ba1467a, type: 3}
+  m_ShaderKeywords: _DIRECTIONAL_LIGHT _DISABLE_ALBEDO_MAP _HOVER_LIGHT _REFLECTIONS
+    _SPECULAR_HIGHLIGHTS
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
+  m_CustomRenderQueue: 2000
+  stringTagMap:
+    RenderType: Opaque
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
     - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ChannelMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -39,11 +45,19 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - _IridescentSpectrumMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _MainTex:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -56,23 +70,107 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats:
+    - _AlbedoAlphaMode: 0
+    - _AlbedoAssignedAtRuntime: 0
+    - _BlendOp: 0
+    - _BlendedClippingWidth: 1
+    - _BorderLight: 0
+    - _BorderLightOpaque: 0
+    - _BorderLightOpaqueAlpha: 1
+    - _BorderLightReplacesAlbedo: 0
+    - _BorderLightUsesHoverColor: 0
+    - _BorderMinValue: 0.1
+    - _BorderWidth: 0.1
     - _BumpScale: 1
+    - _ClippingBorder: 0
+    - _ClippingBorderWidth: 0.025
+    - _ColorWriteMask: 15
+    - _CullMode: 2
+    - _CustomMode: 0
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
+    - _DirectionalLight: 1
     - _DstBlend: 0
+    - _EdgeSmoothingValue: 0.002
+    - _EnableChannelMap: 0
+    - _EnableEmission: 0
+    - _EnableHoverColorOverride: 0
+    - _EnableLocalSpaceTriplanarMapping: 0
+    - _EnableNormalMap: 0
+    - _EnableProximityLightColorOverride: 0
+    - _EnableSSAA: 0
+    - _EnableTriplanarMapping: 0
+    - _EnvironmentColorIntensity: 0.5
+    - _EnvironmentColorThreshold: 1.5
+    - _EnvironmentColoring: 0
+    - _FadeBeginDistance: 0.85
+    - _FadeCompleteDistance: 0.5
+    - _FadeMinValue: 0
+    - _FluentLightIntensity: 1
     - _GlossMapScale: 1
     - _Glossiness: 0.853
     - _GlossyReflections: 1
+    - _HoverLight: 1
+    - _IgnoreZScale: 0
+    - _IndependentCorners: 0
+    - _InnerGlow: 0
+    - _InnerGlowPower: 4
+    - _Iridescence: 0
+    - _IridescenceAngle: -0.78
+    - _IridescenceIntensity: 0.5
+    - _IridescenceThreshold: 0.05
     - _Metallic: 0.36
+    - _MipmapBias: -2
     - _Mode: 0
+    - _NearLightFade: 0
+    - _NearPlaneFade: 0
+    - _NormalMapScale: 1
     - _OcclusionStrength: 1
     - _Parallax: 0.02
+    - _ProximityLight: 0
+    - _ProximityLightSubtractive: 0
+    - _ProximityLightTwoSided: 0
+    - _Reflections: 1
+    - _Refraction: 0
+    - _RefractiveIndex: 0
+    - _RenderQueueOverride: -1
+    - _RimLight: 0
+    - _RimPower: 0.25
+    - _RoundCornerMargin: 0.01
+    - _RoundCornerRadius: 0.25
+    - _RoundCorners: 0
+    - _Smoothness: 0.853
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
+    - _SphericalHarmonics: 0
     - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComparison: 0
+    - _StencilOperation: 0
+    - _StencilReference: 0
+    - _TriplanarMappingBlendSharpness: 4
     - _UVSec: 0
+    - _VertexColors: 0
+    - _VertexExtrusion: 0
+    - _VertexExtrusionSmoothNormals: 0
+    - _VertexExtrusionValue: 0
+    - _ZOffsetFactor: 0
+    - _ZOffsetUnits: 0
+    - _ZTest: 4
     - _ZWrite: 1
     m_Colors:
+    - _ClippingBorderColor: {r: 1, g: 0.19999996, b: 0, a: 1}
     - _Color: {r: 0, g: 0.4968555, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissiveColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EnvironmentColorX: {r: 1, g: 0, b: 0, a: 1}
+    - _EnvironmentColorY: {r: 0, g: 1, b: 0, a: 1}
+    - _EnvironmentColorZ: {r: 0, g: 0, b: 1, a: 1}
+    - _HoverColorOverride: {r: 1, g: 1, b: 1, a: 1}
+    - _InnerGlowColor: {r: 1, g: 1, b: 1, a: 0.75}
+    - _ProximityLightCenterColorOverride: {r: 1, g: 0, b: 0, a: 0}
+    - _ProximityLightMiddleColorOverride: {r: 0, g: 1, b: 0, a: 0.5}
+    - _ProximityLightOuterColorOverride: {r: 0, g: 0, b: 1, a: 1}
+    - _RimColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _RoundCornersRadius: {r: 0.5, g: 0.5, b: 0.5, a: 0.5}
   m_BuildTextureStacks: []

--- a/BasicSample/Assets/ARAnchor/Materials/UntrackedAnchorMaterial.mat
+++ b/BasicSample/Assets/ARAnchor/Materials/UntrackedAnchorMaterial.mat
@@ -1,0 +1,179 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UntrackedAnchorMaterial
+  m_Shader: {fileID: 4800000, guid: 5c1653eb4e20b76499141de7bc57c063, type: 3}
+  m_ShaderKeywords: _DIRECTIONAL_LIGHT _DISABLE_ALBEDO_MAP _HOVER_LIGHT _REFLECTIONS
+    _SPECULAR_HIGHLIGHTS
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 1
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 2000
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ChannelMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _IridescentSpectrumMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _AlbedoAlphaMode: 0
+    - _AlbedoAssignedAtRuntime: 0
+    - _BlendOp: 0
+    - _BlendedClippingWidth: 1
+    - _BorderLight: 0
+    - _BorderLightOpaque: 0
+    - _BorderLightOpaqueAlpha: 1
+    - _BorderLightReplacesAlbedo: 0
+    - _BorderLightUsesHoverColor: 0
+    - _BorderMinValue: 0.1
+    - _BorderWidth: 0.1
+    - _BumpScale: 1
+    - _ClippingBorder: 0
+    - _ClippingBorderWidth: 0.025
+    - _ColorWriteMask: 15
+    - _CullMode: 2
+    - _CustomMode: 0
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DirectionalLight: 1
+    - _DstBlend: 0
+    - _EdgeSmoothingValue: 0.002
+    - _EnableChannelMap: 0
+    - _EnableEmission: 0
+    - _EnableHoverColorOverride: 0
+    - _EnableLocalSpaceTriplanarMapping: 0
+    - _EnableNormalMap: 0
+    - _EnableProximityLightColorOverride: 0
+    - _EnableSSAA: 0
+    - _EnableTriplanarMapping: 0
+    - _EnvironmentColorIntensity: 0.5
+    - _EnvironmentColorThreshold: 1.5
+    - _EnvironmentColoring: 0
+    - _FadeBeginDistance: 0.85
+    - _FadeCompleteDistance: 0.5
+    - _FadeMinValue: 0
+    - _FluentLightIntensity: 1
+    - _GlossMapScale: 1
+    - _Glossiness: 0.853
+    - _GlossyReflections: 1
+    - _HoverLight: 1
+    - _IgnoreZScale: 0
+    - _IndependentCorners: 0
+    - _InnerGlow: 0
+    - _InnerGlowPower: 4
+    - _Iridescence: 0
+    - _IridescenceAngle: -0.78
+    - _IridescenceIntensity: 0.5
+    - _IridescenceThreshold: 0.05
+    - _Metallic: 0.36
+    - _MipmapBias: -2
+    - _Mode: 0
+    - _NearLightFade: 0
+    - _NearPlaneFade: 0
+    - _NormalMapScale: 1
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _ProximityLight: 0
+    - _ProximityLightSubtractive: 0
+    - _ProximityLightTwoSided: 0
+    - _Reflections: 1
+    - _Refraction: 0
+    - _RefractiveIndex: 0
+    - _RenderQueueOverride: -1
+    - _RimLight: 0
+    - _RimPower: 0.25
+    - _RoundCornerMargin: 0.01
+    - _RoundCornerRadius: 0.25
+    - _RoundCorners: 0
+    - _Smoothness: 0.853
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SphericalHarmonics: 0
+    - _SrcBlend: 1
+    - _Stencil: 0
+    - _StencilComparison: 0
+    - _StencilOperation: 0
+    - _StencilReference: 0
+    - _TriplanarMappingBlendSharpness: 4
+    - _UVSec: 0
+    - _VertexColors: 0
+    - _VertexExtrusion: 0
+    - _VertexExtrusionSmoothNormals: 0
+    - _VertexExtrusionValue: 0
+    - _WireThickness: 100
+    - _ZOffsetFactor: 0
+    - _ZOffsetUnits: 0
+    - _ZTest: 4
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0, g: 0, b: 0, a: 1}
+    - _ClippingBorderColor: {r: 1, g: 0.19999996, b: 0, a: 1}
+    - _Color: {r: 0, g: 0.4968555, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissiveColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EnvironmentColorX: {r: 1, g: 0, b: 0, a: 1}
+    - _EnvironmentColorY: {r: 0, g: 1, b: 0, a: 1}
+    - _EnvironmentColorZ: {r: 0, g: 0, b: 1, a: 1}
+    - _HoverColorOverride: {r: 1, g: 1, b: 1, a: 1}
+    - _InnerGlowColor: {r: 1, g: 1, b: 1, a: 0.75}
+    - _ProximityLightCenterColorOverride: {r: 1, g: 0, b: 0, a: 0}
+    - _ProximityLightMiddleColorOverride: {r: 0, g: 1, b: 0, a: 0.5}
+    - _ProximityLightOuterColorOverride: {r: 0, g: 0, b: 1, a: 1}
+    - _RimColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _RoundCornersRadius: {r: 0.5, g: 0.5, b: 0.5, a: 0.5}
+    - _WireColor: {r: 1, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/BasicSample/Assets/ARAnchor/Materials/UntrackedAnchorMaterial.mat.meta
+++ b/BasicSample/Assets/ARAnchor/Materials/UntrackedAnchorMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 228a21d1510694f48a7cb16c1130b388
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BasicSample/Assets/ARAnchor/Prefabs/SampleAnchor.prefab
+++ b/BasicSample/Assets/ARAnchor/Prefabs/SampleAnchor.prefab
@@ -145,6 +145,7 @@ MonoBehaviour:
   meshRenderer: {fileID: 990523026503975020}
   persistentAnchorMaterial: {fileID: 2100000, guid: 4c3ad6584351c784c9af0aff8b196713, type: 2}
   transientAnchorMaterial: {fileID: 2100000, guid: c90b6db173d01004cae48b7db6356449, type: 2}
+  untrackedAnchorMaterial: {fileID: 2100000, guid: 228a21d1510694f48a7cb16c1130b388, type: 2}
 --- !u!114 &9111855319642566706
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/BasicSample/Assets/ARAnchor/Scripts/AnchorsSample.cs
+++ b/BasicSample/Assets/ARAnchor/Scripts/AnchorsSample.cs
@@ -44,6 +44,17 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
                 Debug.Log($"ARAnchorManager not enabled or available; sample anchor functionality will not be enabled.");
                 return;
             }
+
+            foreach (ARAnchor existingAnchor in m_arAnchorManager.trackables)
+            {
+                if (!m_anchors.Contains(existingAnchor))
+                {
+                    Debug.Log($"Anchor added: {existingAnchor.trackableId}, OpenXR Handle: {existingAnchor.GetOpenXRHandle()}");
+                    m_anchors.Add(existingAnchor);
+
+                }
+            }
+
             m_arAnchorManager.anchorsChanged += AnchorsChanged;
 
             m_anchorStore = await m_arAnchorManager.LoadAnchorStoreAsync();
@@ -70,6 +81,7 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
             {
                 m_arAnchorManager.anchorsChanged -= AnchorsChanged;
                 m_anchorStore = null;
+                m_incomingPersistedAnchors.Clear(); 
             }
         }
 

--- a/BasicSample/Assets/ARAnchor/Scripts/AnchorsSample.cs
+++ b/BasicSample/Assets/ARAnchor/Scripts/AnchorsSample.cs
@@ -86,7 +86,7 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
                 // AnchorsChanged update. These double adds are ignored, but other added anchors are processed.
                 if (m_anchors.Contains(added)) continue;
 #endif
-                Debug.Log($"Anchor added from changed event: {added.trackableId}, OpenXR Handle: {added.GetOpenXRHandle()}");
+                Debug.Log($"Anchor added: {added.trackableId}, OpenXR Handle: {added.GetOpenXRHandle()}");
                 m_anchors.Add(added);
 
                 // If this anchor being added was requested from the anchor store, it is recognized here
@@ -98,8 +98,6 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
                         sampleAnchor.Persisted = true;
                         sampleAnchor.TrackingState = added.trackingState;
                     }
-                    added.GetComponent<SampleAnchor>().Name = m_incomingPersistedAnchors[added.trackableId];
-                    added.GetComponent<SampleAnchor>().Persisted = true;
                     m_incomingPersistedAnchors.Remove(added.trackableId);
                 }
             }

--- a/BasicSample/Assets/ARAnchor/Scripts/AnchorsSample.cs
+++ b/BasicSample/Assets/ARAnchor/Scripts/AnchorsSample.cs
@@ -40,8 +40,7 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
 
         protected async void OnEnable()
         {
-            m_arAnchorManager = GetComponent<ARAnchorManager>();
-            if (!m_arAnchorManager.enabled || m_arAnchorManager.subsystem == null)
+            if (!TryGetComponent(out m_arAnchorManager) || !m_arAnchorManager.enabled || m_arAnchorManager.subsystem == null)
             {
                 Debug.Log($"ARAnchorManager not enabled or available; sample anchor functionality will not be enabled.");
                 return;

--- a/BasicSample/Assets/ARAnchor/Scripts/AnchorsSample.cs
+++ b/BasicSample/Assets/ARAnchor/Scripts/AnchorsSample.cs
@@ -16,7 +16,6 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
     /// This sample detects air taps, creating new unpersisted anchors at the locations. Air tapping 
     /// again near these anchors toggles their persistence, backed by the <c>XRAnchorStore</c>.
     /// </summary>
-
     [RequireComponent(typeof(ARAnchorManager))]
     public class AnchorsSample : MonoBehaviour
     {
@@ -70,6 +69,7 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
             if (m_arAnchorManager != null)
             {
                 m_arAnchorManager.anchorsChanged -= AnchorsChanged;
+                m_anchorStore = null;
             }
         }
 

--- a/BasicSample/Assets/ARAnchor/Scripts/AnchorsSample.cs
+++ b/BasicSample/Assets/ARAnchor/Scripts/AnchorsSample.cs
@@ -49,7 +49,7 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
             {
                 if (!m_anchors.Contains(existingAnchor))
                 {
-                    Debug.Log($"Anchor added: {existingAnchor.trackableId}, OpenXR Handle: {existingAnchor.GetOpenXRHandle()}");
+                    Debug.Log($"Anchor added from ARAnchorManager's trackables: {existingAnchor.trackableId}, OpenXR Handle: {existingAnchor.GetOpenXRHandle()}");
                     m_anchors.Add(existingAnchor);
 
                 }
@@ -97,7 +97,7 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
                 // AnchorsChanged update. These double adds are ignored, but other added anchors are processed.
                 if (m_anchors.Contains(added)) continue;
 #endif
-                Debug.Log($"Anchor added: {added.trackableId}, OpenXR Handle: {added.GetOpenXRHandle()}");
+                Debug.Log($"Anchor added from ARAnchorsChangedEvent: {added.trackableId}, OpenXR Handle: {added.GetOpenXRHandle()}");
                 m_anchors.Add(added);
 
                 // If this anchor being added was requested from the anchor store, it is recognized here

--- a/BasicSample/Assets/ARAnchor/Scripts/AnchorsSample.cs
+++ b/BasicSample/Assets/ARAnchor/Scripts/AnchorsSample.cs
@@ -20,13 +20,13 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
     [RequireComponent(typeof(ARAnchorManager))]
     public class AnchorsSample : MonoBehaviour
     {
-
         [SerializeField]
         private GameObject m_anchorsContainer;
 
         private bool[] m_wasTapping = { true, true };
         private bool m_airTapToCreateEnabled = true;
         private bool m_airTapToCreateEnabledChangedThisUpdate = false;
+
         public void ToggleAirTapToCreateEnabled()
         {
             m_airTapToCreateEnabled = !m_airTapToCreateEnabled;
@@ -38,7 +38,7 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
         private XRAnchorStore m_anchorStore = null;
         private Dictionary<TrackableId, string> m_incomingPersistedAnchors = new Dictionary<TrackableId, string>();
 
-        async void Start()
+        protected async void OnEnable()
         {
             m_arAnchorManager = GetComponent<ARAnchorManager>();
             if (!m_arAnchorManager.enabled || m_arAnchorManager.subsystem == null)
@@ -66,7 +66,15 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
             }
         }
 
-        public void AnchorsChanged(ARAnchorsChangedEventArgs eventArgs)
+        protected void OnDisable()
+        {
+            if (m_arAnchorManager != null)
+            {
+                m_arAnchorManager.anchorsChanged -= AnchorsChanged;
+            }
+        }
+
+        private void AnchorsChanged(ARAnchorsChangedEventArgs eventArgs)
         {
             foreach (var added in eventArgs.added)
             {

--- a/BasicSample/Assets/ARAnchor/Scripts/SampleAnchor.cs
+++ b/BasicSample/Assets/ARAnchor/Scripts/SampleAnchor.cs
@@ -82,10 +82,10 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
         {
             if (m_textChanged && text != null)
             {
-                string info = Persisted ? $"\"{Name}\": " : "";
+                string info = Persisted ? $"Name: \"{Name}\"" : "";
                 if (m_arAnchor != null)
                 {
-                    info += $"{m_arAnchor.trackableId}\nTracking State: {TrackingState}";
+                    info = $"{m_arAnchor.trackableId}\n{info}{(Persisted ? ", " : "")}Tracking State: {TrackingState}";
                 }
 
                 if (text.text != info)

--- a/BasicSample/Assets/ARAnchor/Scripts/SampleAnchor.cs
+++ b/BasicSample/Assets/ARAnchor/Scripts/SampleAnchor.cs
@@ -21,6 +21,8 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
         private Material persistentAnchorMaterial = null;
         [SerializeField]
         private Material transientAnchorMaterial = null;
+        [SerializeField]
+        private Material untrackedAnchorMaterial = null;
 
         private bool m_textChanged = true;
         private ARAnchor m_arAnchor;
@@ -49,7 +51,8 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
                 {
                     m_persisted = value;
                     m_textChanged = true;
-                    meshRenderer.material = m_persisted ? persistentAnchorMaterial : transientAnchorMaterial;
+                    meshRenderer.material = m_trackingState == TrackingState.Tracking
+                        ? (m_persisted ? persistentAnchorMaterial : transientAnchorMaterial) : untrackedAnchorMaterial;
                 }
             }
         }
@@ -64,6 +67,8 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
                 {
                     m_trackingState = value;
                     m_textChanged = true;
+                    meshRenderer.material = m_trackingState == TrackingState.Tracking
+                        ? (m_persisted ? persistentAnchorMaterial : transientAnchorMaterial) : untrackedAnchorMaterial;
                 }
             }
         }
@@ -80,7 +85,7 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
                 string info = Persisted ? $"\"{Name}\": " : "";
                 if (m_arAnchor != null)
                 {
-                    info = $"{m_arAnchor.trackableId}\n{m_arAnchor.trackingState} " + info;
+                    info += $"{m_arAnchor.trackableId}\nTracking: {TrackingState}";
                 }
 
                 if (text.text != info)

--- a/BasicSample/Assets/ARAnchor/Scripts/SampleAnchor.cs
+++ b/BasicSample/Assets/ARAnchor/Scripts/SampleAnchor.cs
@@ -82,11 +82,7 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
         {
             if (m_textChanged && text != null)
             {
-                string info = Persisted ? $"Name: \"{Name}\"" : "";
-                if (m_arAnchor != null)
-                {
-                    info = $"{m_arAnchor.trackableId}\n{info}{(Persisted ? ", " : "")}Tracking State: {TrackingState}";
-                }
+                string info = $"{m_arAnchor.trackableId}\n{(Persisted ? $"Name: \"{Name}\", " : "")}Tracking State: {TrackingState}";
 
                 if (text.text != info)
                 {

--- a/BasicSample/Assets/ARAnchor/Scripts/SampleAnchor.cs
+++ b/BasicSample/Assets/ARAnchor/Scripts/SampleAnchor.cs
@@ -85,7 +85,7 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
                 string info = Persisted ? $"\"{Name}\": " : "";
                 if (m_arAnchor != null)
                 {
-                    info += $"{m_arAnchor.trackableId}\nTracking: {TrackingState}";
+                    info += $"{m_arAnchor.trackableId}\nTracking State: {TrackingState}";
                 }
 
                 if (text.text != info)

--- a/BasicSample/Assets/ARAnchor/Scripts/SampleAnchor.cs
+++ b/BasicSample/Assets/ARAnchor/Scripts/SampleAnchor.cs
@@ -88,6 +88,8 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
                 {
                     text.text = info;
                 }
+
+                m_textChanged = false;
             }
         }
     }


### PR DESCRIPTION
1. Updates our anchor materials to use the MRTK Standard shader
2. Adds a new "untracked anchor material" which uses the MRTK Wireframe shader to display a red wireframe when the anchor is untracked
    ![20220513_151747_HoloLens](https://user-images.githubusercontent.com/3580640/168396378-130dfcae-97e2-4c1e-8614-44b1487726fb.jpg)
4. Minor improvements to patterns in the sample