### PR TITLE
Text Panel Improvements

### DIFF
--- a/BasicSample/Assets/ARAnchor/ARAnchor.unity
+++ b/BasicSample/Assets/ARAnchor/ARAnchor.unity
@@ -667,11 +667,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8736328729583821219, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_LocalScale.x
-      value: 0.768
+      value: 1.0345
       objectReference: {fileID: 0}
     - target: {fileID: 8736328729583821219, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.26
+      value: 0.161
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
@@ -758,34 +758,6 @@ PrefabInstance:
     - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
       propertyPath: m_RootOrder
       value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x

--- a/BasicSample/Assets/ARAnchor/ARAnchor.unity
+++ b/BasicSample/Assets/ARAnchor/ARAnchor.unity
@@ -594,12 +594,12 @@ PrefabInstance:
     - target: {fileID: 2478658878998671300, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_Text
       value: "AR Anchors and Anchor Persistence\n\n- Air tap anywhere to create an
-        AR\r Anchor, represented as blue cube.\n- Air tap at an anchor's cube to
-        toggle anchor\r persistence. A green cube represents that the anchor is being
-        persisted in the Anchor\r Store.\n- The \"Clear Anchor Store\" button removes
-        all persisted anchors\r from the Anchor Store. All green cubes would turn
-        blue.\n- The \"Clear all\r anchors in scene\" button deletes all anchors
-        in the scene. All cubes will disappear but persistence is preserved.\n"
+        AR Anchor, represented as blue cube.\n- Air tap at an anchor's cube to
+        toggle anchor persistence. A green cube represents that the anchor is being
+        persisted in the Anchor Store.\n- The \"Clear Anchor Store\" button removes
+        all persisted anchors from the Anchor Store. All green cubes would turn
+        blue.\n- The \"Clear all anchors in scene\" button deletes all anchors
+        in the scene. All cubes will disappear but persistence is preserved."
       objectReference: {fileID: 0}
     - target: {fileID: 2478658878998671300, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_CharacterSize

--- a/BasicSample/Assets/ARMesh/ARMesh.unity
+++ b/BasicSample/Assets/ARMesh/ARMesh.unity
@@ -605,34 +605,6 @@ PrefabInstance:
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
@@ -647,10 +619,6 @@ PrefabInstance:
     - target: {fileID: 4944742623540133948, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
       propertyPath: m_Name
       value: SampleSceneUtilities
-      objectReference: {fileID: 0}
-    - target: {fileID: 5838703338297241233, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_Enabled
-      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
@@ -696,7 +664,7 @@ PrefabInstance:
     - target: {fileID: 1686379045559848377, guid: 9a7c24f281a2c3d45a9b8befe608bf77, type: 3}
       propertyPath: constraintsManager
       value: 
-      objectReference: {fileID: 1703948687}
+      objectReference: {fileID: 0}
     - target: {fileID: 2110343543999718018, guid: 9a7c24f281a2c3d45a9b8befe608bf77, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0.024
@@ -840,14 +808,3 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 9185878736382567157, guid: 9a7c24f281a2c3d45a9b8befe608bf77, type: 3}
   m_PrefabInstance: {fileID: 1703948684}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1703948687 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 9222609700449318417, guid: 9a7c24f281a2c3d45a9b8befe608bf77, type: 3}
-  m_PrefabInstance: {fileID: 1703948684}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a98de877dee5fc341b4eb59dfdab266c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/BasicSample/Assets/ARPlane/ARPlane.unity
+++ b/BasicSample/Assets/ARPlane/ARPlane.unity
@@ -446,34 +446,6 @@ PrefabInstance:
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}

--- a/BasicSample/Assets/ARRaycast/ARRaycast.unity
+++ b/BasicSample/Assets/ARRaycast/ARRaycast.unity
@@ -212,34 +212,6 @@ PrefabInstance:
       value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
@@ -581,7 +553,7 @@ PrefabInstance:
     - target: {fileID: 1686379045559848377, guid: 9a7c24f281a2c3d45a9b8befe608bf77, type: 3}
       propertyPath: constraintsManager
       value: 
-      objectReference: {fileID: 1023725451}
+      objectReference: {fileID: 0}
     - target: {fileID: 2110343543999718018, guid: 9a7c24f281a2c3d45a9b8befe608bf77, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0.024
@@ -725,17 +697,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 9185878736382567157, guid: 9a7c24f281a2c3d45a9b8befe608bf77, type: 3}
   m_PrefabInstance: {fileID: 1023725448}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1023725451 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 9222609700449318417, guid: 9a7c24f281a2c3d45a9b8befe608bf77, type: 3}
-  m_PrefabInstance: {fileID: 1023725448}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a98de877dee5fc341b4eb59dfdab266c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1051198914
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/BasicSample/Assets/MainMenu.unity
+++ b/BasicSample/Assets/MainMenu.unity
@@ -540,7 +540,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2313261133033253179, guid: 6dfc5f0a5fe04f94ab15177720f4bf05, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.06
+      value: 0.025
       objectReference: {fileID: 0}
     - target: {fileID: 2313261133033253179, guid: 6dfc5f0a5fe04f94ab15177720f4bf05, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1188,26 +1188,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.15
       objectReference: {fileID: 0}
     - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
-      propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}

--- a/BasicSample/Assets/Shared/Prefabs/SampleSceneUtilities.prefab
+++ b/BasicSample/Assets/Shared/Prefabs/SampleSceneUtilities.prefab
@@ -523,11 +523,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8736328729583821219, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_LocalScale.x
-      value: 0.48
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 8736328729583821219, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.08
+      value: 0.137
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
@@ -602,11 +602,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8736328729583821219, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_LocalScale.x
-      value: 0.28800002
+      value: 0.3
       objectReference: {fileID: 0}
     - target: {fileID: 8736328729583821219, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.048
+      value: 0.0822
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dfa794c1410554c44baf341ace4e9495, type: 3}

--- a/BasicSample/Assets/Shared/Prefabs/SampleSceneUtilities.prefab
+++ b/BasicSample/Assets/Shared/Prefabs/SampleSceneUtilities.prefab
@@ -505,9 +505,21 @@ PrefabInstance:
       propertyPath: m_Text
       value: Runtime Info ...
       objectReference: {fileID: 0}
+    - target: {fileID: 2478658878998671300, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
+      propertyPath: m_Anchor
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2478658878998671300, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
+      propertyPath: m_CharacterSize
+      value: 0.006
+      objectReference: {fileID: 0}
     - target: {fileID: 3053082487779848052, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_size.x
       value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 3053082487779848052, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
+      propertyPath: m_fontScale
+      value: 0.6
       objectReference: {fileID: 0}
     - target: {fileID: 7471063828548225205, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_RootOrder
@@ -515,7 +527,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7471063828548225205, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.3
+      value: 0.45
       objectReference: {fileID: 0}
     - target: {fileID: 7471063828548225205, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_LocalPosition.z
@@ -523,11 +535,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8736328729583821219, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_LocalScale.x
-      value: 0.5
+      value: 0.3
       objectReference: {fileID: 0}
     - target: {fileID: 8736328729583821219, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.137
+      value: 0.0822
+      objectReference: {fileID: 0}
+    - target: {fileID: 8736328729583821219, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.011100001
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
@@ -566,7 +582,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2478658878998671300, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_Text
-      value: Unity Logs ...
+      value: 'Unity Logging...
+
+        Anything visible in the Unity console will
+        appear here as well.'
+      objectReference: {fileID: 0}
+    - target: {fileID: 2478658878998671300, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
+      propertyPath: m_Anchor
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2478658878998671300, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_CharacterSize
@@ -582,31 +605,43 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7471063828548225205, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.2
+      value: 0.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 7471063828548225205, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.45
       objectReference: {fileID: 0}
     - target: {fileID: 7471063828548225205, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1.2
+      value: 1.4
       objectReference: {fileID: 0}
     - target: {fileID: 7471063828548225205, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.92387956
+      value: 0.953717
       objectReference: {fileID: 0}
     - target: {fileID: 7471063828548225205, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.38268343
+      value: 0.30070576
       objectReference: {fileID: 0}
     - target: {fileID: 7471063828548225205, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 45
+      value: 35
       objectReference: {fileID: 0}
     - target: {fileID: 8736328729583821219, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_LocalScale.x
-      value: 0.3
+      value: 0.57960004
       objectReference: {fileID: 0}
     - target: {fileID: 8736328729583821219, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.0822
+      value: 0.1044
+      objectReference: {fileID: 0}
+    - target: {fileID: 8736328729583821219, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.25980002
+      objectReference: {fileID: 0}
+    - target: {fileID: 8736328729583821219, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.022200001
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dfa794c1410554c44baf341ace4e9495, type: 3}

--- a/SampleShared/Samples/TextPanel/TextPanel.cs
+++ b/SampleShared/Samples/TextPanel/TextPanel.cs
@@ -23,12 +23,16 @@ namespace Microsoft.MixedReality.OpenXR.Sample
         [SerializeField]
         private Color m_backgroundColor = Color.gray;
 
+        [SerializeField]
+        private int m_minimumWidth = 400;
+
         private TextMesh m_textMesh;
         private GameObject m_background;
         private Renderer m_foregroundRenderer;
         private Renderer m_backgroundRenderer;
         private IList<ITextProvider> m_textProviders;
         private string[] m_lines;
+        private const float padding = 10;
 
         void Start()
         {
@@ -65,27 +69,36 @@ namespace Microsoft.MixedReality.OpenXR.Sample
         private void UpdateTextLayout()
         {
             // Determine the line width
-            m_lines = m_textMesh.text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+            m_lines = m_textMesh.text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None); // "\r" will not show as a return in the Unity editor or TextMesh.
 
             int maxLength = 0;
             if (m_lines != null && m_lines.Length > 0)
             {
+                Font font = m_textMesh.font;
                 foreach (var line in m_lines)
                 {
-                    maxLength = Math.Max(maxLength, line.Length);
+                    int lineLength = 0;
+                    foreach (var chr in line)
+                    {
+                        CharacterInfo charInfo;
+                        font.GetCharacterInfo(chr, out charInfo, m_textMesh.fontSize);
+                        lineLength += charInfo.advance;
+                    }
+
+                    maxLength = Math.Max(maxLength, lineLength);
                 }
             }
 
-            // Display each line with about 30 chars.
-            maxLength = Math.Max(20, maxLength);
+            // Ensure the size is at least the minimumWidth
+            maxLength = Math.Max(m_minimumWidth, maxLength);
 
             m_textMesh.characterSize = 0.01f * m_fontScale;
 
             // Adjust background panel size;
             {
                 var scale = m_background.transform.localScale;
-                scale.x = m_textMesh.characterSize * (maxLength + 10) * 1.6f;
-                scale.y = Math.Max(2, m_lines.Length) * ((m_textMesh.lineSpacing + 1) * m_textMesh.characterSize) * 2;
+                scale.x = m_textMesh.characterSize * (0.1f * maxLength + m_padding);
+                scale.y = m_textMesh.characterSize * (3.7f * m_lines.Length * m_textMesh.lineSpacing + m_padding);
                 scale.z = 0.001f;
                 m_background.transform.localScale = scale;
             }

--- a/SampleShared/Samples/TextPanel/TextPanel.cs
+++ b/SampleShared/Samples/TextPanel/TextPanel.cs
@@ -94,13 +94,51 @@ namespace Microsoft.MixedReality.OpenXR.Sample
 
             m_textMesh.characterSize = 0.01f * m_fontScale;
 
+            const float scaleX = 0.1f;
+            const float scaleY = 3.7f;
             // Adjust background panel size;
             {
                 var scale = m_background.transform.localScale;
-                scale.x = m_textMesh.characterSize * (0.1f * maxLength + m_padding);
-                scale.y = m_textMesh.characterSize * (3.7f * m_lines.Length * m_textMesh.lineSpacing + m_padding);
+                scale.x = m_textMesh.characterSize * (scaleX * maxLength + m_padding);
+                scale.y = m_textMesh.characterSize * (scaleY * m_lines.Length * m_textMesh.lineSpacing + m_padding);
                 scale.z = 0.001f;
                 m_background.transform.localScale = scale;
+
+                var position = m_background.transform.localPosition;
+
+                // Set horizontal position
+                if (m_textMesh.anchor == TextAnchor.UpperLeft ||
+                    m_textMesh.anchor == TextAnchor.MiddleLeft ||
+                    m_textMesh.anchor == TextAnchor.LowerLeft)
+                {
+                    position.x = m_textMesh.characterSize * (scaleX * maxLength) / 2;
+                }
+                else if (m_textMesh.anchor == TextAnchor.UpperRight ||
+                         m_textMesh.anchor == TextAnchor.MiddleRight ||
+                         m_textMesh.anchor == TextAnchor.LowerRight)
+                {
+                    position.x = -m_textMesh.characterSize * (scaleX * maxLength) / 2;
+                }
+                else
+                    position.x = 0;
+
+                // Set vertical position
+                if (m_textMesh.anchor == TextAnchor.UpperLeft ||
+                    m_textMesh.anchor == TextAnchor.UpperCenter ||
+                    m_textMesh.anchor == TextAnchor.UpperRight)
+                {
+                    position.y = -m_textMesh.characterSize * (scaleY * m_lines.Length * m_textMesh.lineSpacing) / 2;
+                }
+                else if (m_textMesh.anchor == TextAnchor.LowerLeft ||
+                         m_textMesh.anchor == TextAnchor.LowerCenter ||
+                         m_textMesh.anchor == TextAnchor.LowerRight)
+                {
+                    position.y = m_textMesh.characterSize * (scaleY * m_lines.Length * m_textMesh.lineSpacing) / 2;
+                }
+                else
+                    position.y = 0;
+
+                m_background.transform.localPosition = position;
             }
         }
 

--- a/SampleShared/Samples/TextPanel/TextPanel.cs
+++ b/SampleShared/Samples/TextPanel/TextPanel.cs
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.OpenXR.Sample
         private Renderer m_backgroundRenderer;
         private IList<ITextProvider> m_textProviders;
         private string[] m_lines;
-        private const float padding = 10;
+        private const float m_padding = 10;
 
         void Start()
         {

--- a/SampleShared/Samples/TextPanel/TextPanel.prefab
+++ b/SampleShared/Samples/TextPanel/TextPanel.prefab
@@ -48,7 +48,7 @@ MonoBehaviour:
   m_fontScale: 1
   m_foregroundColor: {r: 1, g: 1, b: 1, a: 1}
   m_backgroundColor: {r: 0.26666668, g: 0.29411766, b: 0.32941177, a: 1}
-  minimumWidth: 400
+  m_minimumWidth: 400
 --- !u!1 &3954227148511934971
 GameObject:
   m_ObjectHideFlags: 0

--- a/SampleShared/Samples/TextPanel/TextPanel.prefab
+++ b/SampleShared/Samples/TextPanel/TextPanel.prefab
@@ -48,6 +48,7 @@ MonoBehaviour:
   m_fontScale: 1
   m_foregroundColor: {r: 1, g: 1, b: 1, a: 1}
   m_backgroundColor: {r: 0.26666668, g: 0.29411766, b: 0.32941177, a: 1}
+  minimumWidth: 400
 --- !u!1 &3954227148511934971
 GameObject:
   m_ObjectHideFlags: 0
@@ -76,7 +77,7 @@ Transform:
   m_GameObject: {fileID: 3954227148511934971}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.232, y: 0.08, z: 0.001}
+  m_LocalScale: {x: 1.074, y: 0.174, z: 0.001}
   m_Children: []
   m_Father: {fileID: 7471063828548225205}
   m_RootOrder: 1


### PR DESCRIPTION
**Resizes More Accurately**

![image](https://user-images.githubusercontent.com/12822425/168389681-b162ebbe-e142-4378-b038-26cd290e72b0.png)

- The text panel now resizes more accurately
- Made minimumWidth a property exposed in the editor
- Fixed a bug where the text panel would treat '\r' characters as new lines, when the Unity editor and TextMesh do not.
- Removed some extra '\r' chars from the ARAnchor text


**Supports All Alignments**

![image](https://user-images.githubusercontent.com/12822425/168403364-d05b4bf8-3a9d-4d60-8f82-b7b7bbfdf524.png)
- Added support for all alignments, just edit the TextMesh anchor

**Re-aligned the samples panels**

![20220513_170628_HoloLens](https://user-images.githubusercontent.com/12822425/168403274-289cb4c8-05c2-4f14-86f9-7fe0575ff688.jpg)
View in the main menu (the runtime info is centered; I'm just at an angle)

![20220513_170652_HoloLens](https://user-images.githubusercontent.com/12822425/168403264-ef95794b-f440-4ad1-8dc7-eea94337bcae.jpg)
View in a different scene (runtime info and logs are higher, out of the way)

- Runtime info panel is now aligned Top Center
- Logging panel is now aligned Top Left
- Cleaned up various prefab overrides in scenes where the overrides weren't doing anything meaningful