### PR TITLE
Fixed a bug where ArgumentNullException when Unity's subsystem is not…

### DIFF
--- a/SampleShared/Samples/TextPanel/RuntimeInfo.cs
+++ b/SampleShared/Samples/TextPanel/RuntimeInfo.cs
@@ -92,9 +92,9 @@ namespace Microsoft.MixedReality.OpenXR.Sample
 
         private string GetOriginMode()
         {
-            return (m_inputSubsystem == null && m_inputSubsystem.running)
-                ? "Unknown Origin Mode" 
-                : m_inputSubsystem.GetTrackingOriginMode().ToString();
+            return (m_inputSubsystem != null && m_inputSubsystem.running)
+                ? m_inputSubsystem.GetTrackingOriginMode().ToString()
+                : "Unknown Origin Mode";
         }
 
         private static XRInputSubsystem GetXRInputSubsystem()

--- a/SampleShared/Samples/TextPanel/RuntimeInfo.cs
+++ b/SampleShared/Samples/TextPanel/RuntimeInfo.cs
@@ -92,7 +92,9 @@ namespace Microsoft.MixedReality.OpenXR.Sample
 
         private string GetOriginMode()
         {
-            return m_inputSubsystem == null ? "Unknown Origin Mode" : m_inputSubsystem.GetTrackingOriginMode().ToString();
+            return (m_inputSubsystem == null && m_inputSubsystem.running)
+                ? "Unknown Origin Mode" 
+                : m_inputSubsystem.GetTrackingOriginMode().ToString();
         }
 
         private static XRInputSubsystem GetXRInputSubsystem()

--- a/SampleShared/Samples/TextPanel/TextPanel.cs
+++ b/SampleShared/Samples/TextPanel/TextPanel.cs
@@ -57,10 +57,17 @@ namespace Microsoft.MixedReality.OpenXR.Sample
         {
             if (m_textProviders != null && m_textProviders.Count > 0)
             {
+                bool shouldAddLineBreak = false;
                 StringBuilder stringBuilder = new StringBuilder();
                 foreach (var textProvider in m_textProviders)
                 {
+                    if (shouldAddLineBreak)
+                    {
+                        stringBuilder.AppendLine();
+                    }
+
                     stringBuilder.Append(textProvider.UpdateText());
+                    shouldAddLineBreak = true;
                 }
 
                 var text = stringBuilder.ToString();


### PR DESCRIPTION
… running, and added a missing linebreak before the second text provider in text panel.  Fixed https://github.com/microsoft/Unity-MR-Plugin/issues/1208