### PR TITLE
Update AnchorSample.cs parent object for anchor instantiation

### DIFF
--- a/BasicSample/Assets/ARAnchor/ARAnchor.unity
+++ b/BasicSample/Assets/ARAnchor/ARAnchor.unity
@@ -358,7 +358,6 @@ RectTransform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -0.001}
   m_LocalScale: {x: 0.00641, y: 0.00641, z: 0.00641}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1703948685}
   m_RootOrder: 4
@@ -454,12 +453,12 @@ MonoBehaviour:
   m_margin: {x: 0, y: 1.1615484, z: 0.9536365, w: 1.6841211}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
-  _SortingLayer: 0
-  _SortingLayerID: 0
-  _SortingOrder: 0
   m_hasFontAssetChanged: 0
   m_renderer: {fileID: 194343093}
   m_maskType: 0
+  _SortingLayer: 0
+  _SortingLayerID: 0
+  _SortingOrder: 0
 --- !u!23 &194343093
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -471,7 +470,6 @@ MeshRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -502,37 +500,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &203646569
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 203646570}
-  m_Layer: 0
-  m_Name: Anchors Container
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &203646570
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 203646569}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &223974226
 GameObject:
   m_ObjectHideFlags: 0
@@ -575,7 +542,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -593,13 +559,22 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2478658878998671300, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_Text
-      value: "AR Anchors and Anchor Persistence\n\n- Air tap anywhere to create an
-        AR Anchor, represented as blue cube.\n- Air tap at an anchor's cube to
-        toggle anchor persistence. A green cube represents that the anchor is being
-        persisted in the Anchor Store.\n- The \"Clear Anchor Store\" button removes
-        all persisted anchors from the Anchor Store. All green cubes would turn
-        blue.\n- The \"Clear all anchors in scene\" button deletes all anchors
-        in the scene. All cubes will disappear but persistence is preserved."
+      value: 'AR Anchors and Anchor Persistence
+
+
+        - Air tap anywhere to create
+        an AR Anchor, represented as blue cube.
+
+        - Air tap at an anchor''s
+        cube to toggle anchor persistence. A green cube represents that the anchor
+        is being persisted in the Anchor Store.
+
+        - The "Clear Anchor Store"
+        button removes all persisted anchors from the Anchor Store. All green cubes
+        would turn blue.
+
+        - The "Clear all anchors in scene" button deletes
+        all anchors in the scene. All cubes will disappear but persistence is preserved.'
       objectReference: {fileID: 0}
     - target: {fileID: 2478658878998671300, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_CharacterSize
@@ -611,7 +586,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7471063828548225205, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 7471063828548225205, guid: dfa794c1410554c44baf341ace4e9495, type: 3}
       propertyPath: m_LocalScale.x
@@ -717,7 +692,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
@@ -734,7 +708,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3d076bfeed6ab6d43bfb71e0cbcbe867, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_anchorsContainer: {fileID: 203646569}
 --- !u!114 &1158897731
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -757,7 +730,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4944742623540133923, guid: 96d27fe6fab8a3245ac58a83efbe3a70, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -921,7 +894,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6497819335467242799, guid: 9a7c24f281a2c3d45a9b8befe608bf77, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 6497819335467242799, guid: 9a7c24f281a2c3d45a9b8befe608bf77, type: 3}
       propertyPath: m_LocalPosition.x

--- a/BasicSample/Assets/ARAnchor/Scripts/AnchorsSample.cs
+++ b/BasicSample/Assets/ARAnchor/Scripts/AnchorsSample.cs
@@ -17,11 +17,9 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
     /// again near these anchors toggles their persistence, backed by the <c>XRAnchorStore</c>.
     /// </summary>
     [RequireComponent(typeof(ARAnchorManager))]
+    [RequireComponent(typeof(ARSessionOrigin))]
     public class AnchorsSample : MonoBehaviour
     {
-        [SerializeField]
-        private GameObject m_anchorsContainer;
-
         private bool[] m_wasTapping = { true, true };
         private bool m_airTapToCreateEnabled = true;
         private bool m_airTapToCreateEnabledChangedThisUpdate = false;
@@ -32,27 +30,21 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
             m_airTapToCreateEnabledChangedThisUpdate = true;
         }
 
+        private ARSessionOrigin m_arSessionOrigin;
         private ARAnchorManager m_arAnchorManager;
         private List<ARAnchor> m_anchors = new List<ARAnchor>();
         private XRAnchorStore m_anchorStore = null;
         private Dictionary<TrackableId, string> m_incomingPersistedAnchors = new Dictionary<TrackableId, string>();
+        bool m_processExistingAnchorsOnAnchorsChanged = false;
 
         protected async void OnEnable()
         {
+            m_arSessionOrigin = GetComponent<ARSessionOrigin>();
+
             if (!TryGetComponent(out m_arAnchorManager) || !m_arAnchorManager.enabled || m_arAnchorManager.subsystem == null)
             {
                 Debug.Log($"ARAnchorManager not enabled or available; sample anchor functionality will not be enabled.");
                 return;
-            }
-
-            foreach (ARAnchor existingAnchor in m_arAnchorManager.trackables)
-            {
-                if (!m_anchors.Contains(existingAnchor))
-                {
-                    Debug.Log($"Anchor added from ARAnchorManager's trackables: {existingAnchor.trackableId}, OpenXR Handle: {existingAnchor.GetOpenXRHandle()}");
-                    m_anchors.Add(existingAnchor);
-
-                }
             }
 
             m_arAnchorManager.anchorsChanged += AnchorsChanged;
@@ -73,6 +65,10 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
                 TrackableId trackableId = m_anchorStore.LoadAnchor(name);
                 m_incomingPersistedAnchors.Add(trackableId, name);
             }
+
+            // Anchors may already exist in the subsystem, but are not guaranteed to be loaded into the scene until
+            // the AnchorsChanged event. Setting this flag tells this app to process existing anchors at that time.
+            m_processExistingAnchorsOnAnchorsChanged = true;
         }
 
         protected void OnDisable()
@@ -87,30 +83,20 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
 
         private void AnchorsChanged(ARAnchorsChangedEventArgs eventArgs)
         {
+            if (m_processExistingAnchorsOnAnchorsChanged)
+            {
+                foreach (ARAnchor existingAnchor in m_arAnchorManager.trackables)
+                {
+                    Debug.Log($"Anchor added from ARAnchorManager's trackables: {existingAnchor.trackableId}, OpenXR Handle: {existingAnchor.GetOpenXRHandle()}");
+                    ProcessAddedAnchor(existingAnchor);
+                }
+                m_processExistingAnchorsOnAnchorsChanged = false;
+            }
+
             foreach (var added in eventArgs.added)
             {
-                // Keep any anchors created by this scene contained within the scene, for multi-scene management.
-                added.transform.SetParent(m_anchorsContainer.transform, worldPositionStays: true);
-
-#if !AR_FOUNDATION_4_1_1_OR_LATER
-                // TryAddAnchor returns the anchor upon success, but it must also be reported in the next
-                // AnchorsChanged update. These double adds are ignored, but other added anchors are processed.
-                if (m_anchors.Contains(added)) continue;
-#endif
                 Debug.Log($"Anchor added from ARAnchorsChangedEvent: {added.trackableId}, OpenXR Handle: {added.GetOpenXRHandle()}");
-                m_anchors.Add(added);
-
-                // If this anchor being added was requested from the anchor store, it is recognized here
-                if (m_incomingPersistedAnchors.TryGetValue(added.trackableId, out string name))
-                {
-                    if (added.TryGetComponent(out SampleAnchor sampleAnchor))
-                    {
-                        sampleAnchor.Name = name;
-                        sampleAnchor.Persisted = true;
-                        sampleAnchor.TrackingState = added.trackingState;
-                    }
-                    m_incomingPersistedAnchors.Remove(added.trackableId);
-                }
+                ProcessAddedAnchor(added);
             }
 
             foreach (ARAnchor updated in eventArgs.updated)
@@ -126,6 +112,26 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
                 Debug.Log($"Anchor removed: {removed.trackableId}");
                 m_anchors.Remove(removed);
             }
+        }
+
+        private void ProcessAddedAnchor(ARAnchor anchor)
+        {
+            if (m_anchors.Contains(anchor))
+                return;
+
+            // If this anchor being added was requested from the anchor store, it is recognized here
+            if (m_incomingPersistedAnchors.TryGetValue(anchor.trackableId, out string name))
+            {
+                if (anchor.TryGetComponent(out SampleAnchor sampleAnchor))
+                {
+                    sampleAnchor.Name = name;
+                    sampleAnchor.Persisted = true;
+                    sampleAnchor.TrackingState = anchor.trackingState;
+                }
+                m_incomingPersistedAnchors.Remove(anchor.trackableId);
+            }
+
+            m_anchors.Add(anchor);
         }
 
         private bool IsTapping(InputDevice device)
@@ -207,7 +213,11 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
         {
 #if AR_FOUNDATION_4_1_1_OR_LATER
             Debug.Log($"Instantiating new GameObject containing an ARAnchor");
-            Instantiate(m_arAnchorManager.anchorPrefab, pose.position, pose.rotation);
+
+            // When instantiating a trackable gameobject, it should be a child of the ARSessionOrigin.trackablesParent GameObject.
+            // If the GameObject is not a child of this trackablesParent, it may not be cleaned up properly in some scenarios,
+            // such as scene changes. This is especially important for applications composed of additive scenes, like this one.
+            Instantiate(m_arAnchorManager.anchorPrefab, pose.position, pose.rotation, m_arSessionOrigin.trackablesParent);
 #else
             ARAnchor newAnchor = m_arAnchorManager.AddAnchor(pose);
             if (newAnchor == null)


### PR DESCRIPTION
⭐ **Feel free to do whatever with this branch while I'm out.**

Targeting 1.4.1-again branch for a smaller diff; I'm expecting these two to be merged at the same time.

- Removes the old anchor container from the ARAnchor scene, using ARSessionOrigin.trackablesParent instead
- Removes the logic for processing existing anchors - these are only relevant in this app if there are already anchors in the subsystem upon loading a scene, which would mean a bug had previously occurred in this sample.

Fixes [#1217](https://github.com/microsoft/Unity-MR-Plugin/issues/1217)