### PR TITLE
Formatting and minor update to speech sample

### DIFF
--- a/SampleShared/Samples/AppRemoting/Scripts/AppRemotingSample.cs
+++ b/SampleShared/Samples/AppRemoting/Scripts/AppRemotingSample.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.MixedReality.OpenXR.Remoting;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using UnityEngine;
-using UnityEngine.XR;
 using UnityEngine.UI;
-using Microsoft.MixedReality.OpenXR.Remoting;
+using UnityEngine.XR;
 
 namespace Microsoft.MixedReality.OpenXR.BasicSample
 {
@@ -105,7 +105,7 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
         private const int m_updateTextCountMax = 30;
         private void Update()
         {
-            if (m_updateTextCount ++ < m_updateTextCountMax)
+            if (m_updateTextCount++ < m_updateTextCountMax)
             {
                 return; // Only need to update text after a while.
             }

--- a/SampleShared/Samples/AppRemoting/Scripts/DisconnectAppRemoting.cs
+++ b/SampleShared/Samples/AppRemoting/Scripts/DisconnectAppRemoting.cs
@@ -1,5 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using UnityEngine;
-using Microsoft.MixedReality.OpenXR.Remoting;
 
 namespace Microsoft.MixedReality.OpenXR.BasicSample
 {

--- a/SampleShared/Samples/AppRemoting/Scripts/EnableOnlyDuringRemotingConnection.cs
+++ b/SampleShared/Samples/AppRemoting/Scripts/EnableOnlyDuringRemotingConnection.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using UnityEngine;
 using Microsoft.MixedReality.OpenXR.Remoting;
+using UnityEngine;
 
 namespace Microsoft.MixedReality.OpenXR.BasicSample
 {

--- a/SampleShared/Samples/Speech/Scripts/SpeechSample.cs
+++ b/SampleShared/Samples/Speech/Scripts/SpeechSample.cs
@@ -1,4 +1,6 @@
-using System.Collections;
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -14,24 +16,27 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
         /// <summary>
         /// The colors which can be recognized by the KeywordRecognizer and applied to the material of scene objects.
         /// </summary>
-        public Dictionary<string, Color> m_colors = new Dictionary<string, Color>(){
-            { "red", new Color(1, 0, 0) } ,
+        private Dictionary<string, Color> m_colors = new Dictionary<string, Color>()
+        {
+            { "red", Color.red } ,
             { "orange", new Color(1, 0.65f, 0) },
-            { "yellow", new Color(1, 1, 0) },
-            { "green", new Color(0, 1, 0) },
-            { "blue", new Color(0, 0, 1) },
-            { "purple", new Color(1, 0, 1) }
+            { "yellow", Color.yellow },
+            { "green", Color.green },
+            { "blue", Color.blue },
+            { "purple", Color.magenta }
         };
-           
+
         /// <summary>
         /// The minimum confidence level to be used by the KeywordRecognizer.
         /// </summary>
-        public ConfidenceLevel m_confidenceLevel = ConfidenceLevel.Medium;
+        [SerializeField, Tooltip("The minimum confidence level to be used by the KeywordRecognizer.")]
+        private ConfidenceLevel m_confidenceLevel = ConfidenceLevel.Medium;
 
         /// <summary>
         /// The material whose color should be changed when a new color is spoken.
         /// </summary>
-        public Material m_material;
+        [SerializeField, Tooltip("The material whose color should be changed when a new color is spoken.")]
+        private Material m_material;
 
         private KeywordRecognizer m_recognizer = null;
 
@@ -47,11 +52,12 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
             m_material.color = m_colors[args.text];
         }
 
-        void OnDestroy()
+        private void OnDestroy()
         {
             if (m_recognizer != null)
             {
                 m_recognizer.Stop();
+                m_recognizer.OnPhraseRecognized -= PhraseRecognized;
                 m_recognizer.Dispose();
                 m_recognizer = null;
             }

--- a/SampleShared/Samples/Speech/Scripts/SpeechSample.cs
+++ b/SampleShared/Samples/Speech/Scripts/SpeechSample.cs
@@ -39,9 +39,11 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
         private Material m_material;
 
         private KeywordRecognizer m_recognizer = null;
+        private Color m_originalColor;
 
         private void Start()
         {
+            m_originalColor = m_material.color;
             m_recognizer = new KeywordRecognizer(m_colors.Keys.ToArray(), m_confidenceLevel);
             m_recognizer.OnPhraseRecognized += PhraseRecognized;
             m_recognizer.Start();
@@ -61,6 +63,7 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
                 m_recognizer.Dispose();
                 m_recognizer = null;
             }
+            m_material.color = m_originalColor;
         }
     }
 }


### PR DESCRIPTION
Quick formatting pass, as well as updating the speech sample to cache and restore the material's starting color to not leave the local asset state out of sync.