### PR TITLE
Reduce Eye Tracking Logs

### DIFF
--- a/BasicSample/Assets/Interaction/Scripts/FollowEyeGaze.cs
+++ b/BasicSample/Assets/Interaction/Scripts/FollowEyeGaze.cs
@@ -47,7 +47,7 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
                 {
                     if (wasEyeTrackingValidLastFrame)
                     {
-                    Debug.LogWarning($"Unable to acquire eye tracking device. Have permissions been granted?");
+                        Debug.LogWarning($"Unable to acquire eye tracking device. Have permissions been granted?");
                     }
                     wasEyeTrackingValidLastFrame = false;
                     return;

--- a/BasicSample/Assets/Interaction/Scripts/FollowEyeGaze.cs
+++ b/BasicSample/Assets/Interaction/Scripts/FollowEyeGaze.cs
@@ -17,6 +17,7 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
         private InputDevice eyeTrackingDevice = default(InputDevice);
         private Renderer materialRenderer = null;
         private Material trackedMaterial = null;
+        private bool wasEyeTrackingValidLastFrame = false;
 
         /// <summary>
         /// Toggles the enabled state of this script to actively follow eye gaze or not.
@@ -44,10 +45,15 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
 
                 if (!eyeTrackingDevice.isValid)
                 {
+                    if (wasEyeTrackingValidLastFrame)
+                    {
                     Debug.LogWarning($"Unable to acquire eye tracking device. Have permissions been granted?");
+                    }
+                    wasEyeTrackingValidLastFrame = false;
                     return;
                 }
             }
+            wasEyeTrackingValidLastFrame = true;
 
             // Gets gaze data from the device.
             bool hasData = eyeTrackingDevice.TryGetFeatureValue(CommonUsages.isTracked, out bool isTracked);

--- a/BasicSample/Assets/Interaction/Scripts/FollowEyeGaze.cs
+++ b/BasicSample/Assets/Interaction/Scripts/FollowEyeGaze.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.OpenXR.BasicSample
         private InputDevice eyeTrackingDevice = default(InputDevice);
         private Renderer materialRenderer = null;
         private Material trackedMaterial = null;
-        private bool wasEyeTrackingValidLastFrame = false;
+        private bool wasEyeTrackingValidLastFrame = true;
 
         /// <summary>
         /// Toggles the enabled state of this script to actively follow eye gaze or not.


### PR DESCRIPTION
Currently, the FollowEyeGaze script logs a message every frame if eye tracking device is not valid. This can make it more difficult to debug the sample scenes in Unity editor or remoting apps by filling the logs with repeat messages. 
With this change, the script only logs the message the first frame or if eye tracking is newly lost. 