### PR TITLE
Hide All Hand UI In Interaction Scene

### DIFF
--- a/BasicSample/Assets/Interaction/Interaction.unity
+++ b/BasicSample/Assets/Interaction/Interaction.unity
@@ -132,6 +132,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 36563088}
+  - component: {fileID: 36563089}
   m_Layer: 0
   m_Name: Grip Pose Visuals
   m_TagString: Untagged
@@ -156,6 +157,21 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &36563089
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 36563087}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4cb83e5bfe94b0b438d1ca2d9d9631a4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  handSpheres:
+  - {fileID: 966233179}
+  - {fileID: 1186801974}
 --- !u!1 &55162561
 GameObject:
   m_ObjectHideFlags: 0
@@ -574,6 +590,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 200865411}
+  - component: {fileID: 200865412}
   m_Layer: 0
   m_Name: Aim Pose Visuals
   m_TagString: Untagged
@@ -598,6 +615,21 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &200865412
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 200865410}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4cb83e5bfe94b0b438d1ca2d9d9631a4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  handSpheres:
+  - {fileID: 1499622970}
+  - {fileID: 1408534657}
 --- !u!1001 &202065120
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1238,12 +1270,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 496357015}
-  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 1}
-  m_LocalScale: {x: 0.01, y: 1, z: 0.01}
+  m_LocalScale: {x: 0.01, y: 1, z: 0.009999999}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1410412341}
+  m_Father: {fileID: 1499622971}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!23 &496357017
@@ -1324,6 +1356,11 @@ PrefabInstance:
 --- !u!4 &966233178 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 9045106990711866059, guid: 4b20b684dbbb303469b3eb85d4ebcebc, type: 3}
+  m_PrefabInstance: {fileID: 966233177}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &966233179 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8449468278048138753, guid: 4b20b684dbbb303469b3eb85d4ebcebc, type: 3}
   m_PrefabInstance: {fileID: 966233177}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &968565619
@@ -1752,6 +1789,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 9045106990711866059, guid: 4b20b684dbbb303469b3eb85d4ebcebc, type: 3}
   m_PrefabInstance: {fileID: 1186801972}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1186801974 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8449468278048138753, guid: 4b20b684dbbb303469b3eb85d4ebcebc, type: 3}
+  m_PrefabInstance: {fileID: 1186801972}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1279304718
 GameObject:
   m_ObjectHideFlags: 0
@@ -1826,8 +1868,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 2132408847}
-  - {fileID: 1519917854}
+  - {fileID: 1408534658}
   m_Father: {fileID: 200865411}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1889,10 +1930,10 @@ MonoBehaviour:
   m_TrackingStateInput:
     m_UseReference: 0
     m_Action:
-      m_Name: 
+      m_Name: Tracking State Input
       m_Type: 0
       m_ExpectedControlType: 
-      m_Id: 
+      m_Id: 1625ade3-c4fa-4965-b6f0-242487fcb1d7
       m_Processors: 
       m_Interactions: 
       m_SingletonActionBindings: []
@@ -1932,7 +1973,39 @@ MonoBehaviour:
       m_Action: Rotation
       m_Flags: 0
     m_Flags: 0
-  m_HasMigratedActions: 1
+--- !u!1 &1408534657
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1408534658}
+  m_Layer: 0
+  m_Name: UI (right)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1408534658
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1408534657}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2132408847}
+  - {fileID: 1519917854}
+  m_Father: {fileID: 1388237501}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1410412340
 GameObject:
   m_ObjectHideFlags: 0
@@ -1962,8 +2035,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1687414982}
-  - {fileID: 496357016}
+  - {fileID: 1499622971}
   m_Father: {fileID: 200865411}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2025,10 +2097,10 @@ MonoBehaviour:
   m_TrackingStateInput:
     m_UseReference: 0
     m_Action:
-      m_Name: 
+      m_Name: Tracking State Input
       m_Type: 0
       m_ExpectedControlType: 
-      m_Id: 
+      m_Id: fe2f9aa8-99c5-4ca3-ae10-1f2c3ee4e0d0
       m_Processors: 
       m_Interactions: 
       m_SingletonActionBindings: []
@@ -2068,7 +2140,39 @@ MonoBehaviour:
       m_Action: Rotation
       m_Flags: 0
     m_Flags: 0
-  m_HasMigratedActions: 1
+--- !u!1 &1499622970
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1499622971}
+  m_Layer: 0
+  m_Name: UI (left)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1499622971
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1499622970}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1687414982}
+  - {fileID: 496357016}
+  m_Father: {fileID: 1410412341}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1519917853
 GameObject:
   m_ObjectHideFlags: 0
@@ -2094,12 +2198,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1519917853}
-  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 1}
-  m_LocalScale: {x: 0.01, y: 1, z: 0.01}
+  m_LocalScale: {x: 0.01, y: 1, z: 0.009999999}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1388237501}
+  m_Father: {fileID: 1408534658}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!23 &1519917855
@@ -2764,7 +2868,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 1410412341}
+    m_TransformParent: {fileID: 1499622971}
     m_Modifications:
     - target: {fileID: 3931093669127985773, guid: 4b20b684dbbb303469b3eb85d4ebcebc, type: 3}
       propertyPath: m_RootOrder
@@ -3244,7 +3348,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 1388237501}
+    m_TransformParent: {fileID: 1408534658}
     m_Modifications:
     - target: {fileID: 3931093669127985773, guid: 4b20b684dbbb303469b3eb85d4ebcebc, type: 3}
       propertyPath: m_RootOrder


### PR DESCRIPTION
In the interaction subscene, adds a component to hide aim pose visuals and the axes of the grip pose visuals when hands aren't tracked. 